### PR TITLE
Resolve multiple instances of a plugin being loaded on plugin reload

### DIFF
--- a/injected/src/internal-plugins/plugin-browser/install-plugin.ts
+++ b/injected/src/internal-plugins/plugin-browser/install-plugin.ts
@@ -87,8 +87,8 @@ export const useInstallPlugin = (
       extractModal.close();
 
       try {
-        await smm.Plugins.injectPlugin(plugin.id);
-        await smm.Plugins.load(plugin.id);
+        await smm.Plugins.reloadPlugins();
+        await smm.Plugins.reloadPlugin(plugin.id);
       } catch (err) {
         smm.Toast.addToast(`Error loading plugin ${plugin.name}`, 'error');
         console.error(err);

--- a/injected/src/internal-plugins/plugin-manager/plugin-actions.ts
+++ b/injected/src/internal-plugins/plugin-manager/plugin-actions.ts
@@ -45,6 +45,7 @@ export const usePluginActions = ({
 
   const handleReload = useCallback(async () => {
     try {
+      await smm.Plugins.rebuildPlugin(plugin.id);
       await smm.Plugins.reloadPlugin(plugin.id);
       smm.Toast.addToast(`${plugin.config.name} reloaded!`, 'success');
     } catch (err) {

--- a/rpc/plugins.go
+++ b/rpc/plugins.go
@@ -46,6 +46,13 @@ func (service *PluginsService) Rebuild(r *http.Request, req *RebuildArgs, res *R
 	return service.plugins.RebuildPlugin(req.Id)
 }
 
+type ReloadArgs struct{}
+type ReloadReply struct{}
+
+func (service *PluginsService) Reload(r *http.Request, req *ReloadArgs, res *ReloadReply) error {
+	return service.plugins.Reload()
+}
+
 type SetEnabledArgs struct {
 	Id      string `json:"id"`
 	Enabled bool   `json:"enabled"`


### PR DESCRIPTION
Due to the use of IPC to trigger a reload on the other browser
instances, we only need to call "PluginsService.Rebuild" from
the instance initiating the reload. To accomplish this, I've
moved it to its own "rebuildPlugin" method that is called before
the reloadPlugin method in plugin-actions.ts.

We can then skip sending the "injectPlugin" IPC, as it will be
handled by the "reloadPlugin" IPC on the other browser instances.

To stop the backend from injecting multiple plugin instances
in each browser instance, we now pass the entrypoint in the
"InjectService.InjectPlugin" call, instead of looping in that
method.

Because there is now a call for rebuilding the specific plugin
we are reloading, a "service.plugins.Reload()" is no longer
necessary in InjectService.InjectPlugin. However this does
necessitate adding a call to a new reloadPlugins RPC in the
install-plugin instance, so that the new plugin is loaded into
memory, before being injected to all browser instances using
reloadPlugin.

To avoid unnecessary RPC calls, the "setEnabled" calls have
been moved outside of the IPC-triggered load/unload methods,
so that they will only be called once on the triggering
browser instance.