### PR TITLE
Fix "Load" not injecting plugins that were disabled on startup

### DIFF
--- a/injected/src/services/plugins.ts
+++ b/injected/src/services/plugins.ts
@@ -106,6 +106,11 @@ export class Plugins extends Service {
   }
 
   private async _load(pluginId: string) {
+    // If the plugin hasn't been injected, attempt to inject it
+    if (!window.smmPlugins?.[pluginId]) {
+      await this._injectPlugin(pluginId);
+    }
+    
     await this.smm.loadPlugin(pluginId);
   }
 


### PR DESCRIPTION
When _load is called, check to make sure the plugin exists in window.smmPlugins and if not, inject it.

Fixes https://todo.sr.ht/~avery/crankshaft/46