### PR TITLE
Remove tar during install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ go.work
 .scratch/
 # Release output
 .dist/
+
+# ignore VSCode config
+.vscode/

--- a/injected/src/internal-plugins/plugin-browser/install-plugin.ts
+++ b/injected/src/internal-plugins/plugin-browser/install-plugin.ts
@@ -82,6 +82,9 @@ export const useInstallPlugin = (
         smm.Toast.addToast(`Error extracting ${fileName}`, 'error');
         extractModal.close();
         return;
+      } finally {
+        // Whether the extraction suceeded or failed, remove the donwload tar file
+        smm.FS.removeFile(join(PLUGINS_DIR, fileName));
       }
 
       extractModal.close();

--- a/injected/src/services/fs.ts
+++ b/injected/src/services/fs.ts
@@ -42,6 +42,12 @@ export class FS extends Service {
     return (await getRes()).data.trim();
   }
 
+  removeFile(path: string) {
+    info('removeFile', path);
+
+    return rpcRequest<{ path: string }, {}>('FSService.RemoveFile', { path });
+  }
+
   untar(tarPath: string, destPath: string) {
     info('untar', { tarPath, destPath });
 

--- a/injected/src/services/fs.ts
+++ b/injected/src/services/fs.ts
@@ -45,7 +45,12 @@ export class FS extends Service {
   removeFile(path: string) {
     info('removeFile', path);
 
-    return rpcRequest<{ path: string }, {}>('FSService.RemoveFile', { path });
+    const { getRes } = rpcRequest<{ path: string }, {}>(
+      'FSService.RemoveFile',
+      { path }
+    );
+
+    return getRes();
   }
 
   untar(tarPath: string, destPath: string) {

--- a/rpc/fs.go
+++ b/rpc/fs.go
@@ -88,6 +88,25 @@ func (service *FSService) ReadFile(r *http.Request, req *ReadFileArgs, res *Read
 	return nil
 }
 
+type RemoveFileArgs struct {
+	Path string `json:"path"`
+}
+
+type RemoveFileReply struct {
+}
+
+func (service *FSService) RemoveFile(r *http.Request, req *RemoveFileArgs, res *RemoveFileReply) error {
+	path := pathutil.SubstituteHomeAndXdg(req.Path)
+
+	err := os.Remove(path)
+	if err != nil {
+		log.Println("Error removing file", err)
+		return err
+	}
+
+	return nil
+}
+
 type UntarArgs struct {
 	TarPath  string `json:"tarPath"`
 	DestPath string `json:"destPath"`


### PR DESCRIPTION
This change adds the ability to remove files to the `FSService`, and then leverages this change to remove downloaded `.tar.gz` files after installing a plugin.

Resolves: https://todo.sr.ht/~avery/crankshaft/56