### PR TITLE
[MERGED] 40 - Keyboard plugins

### DIFF
--- a/build/build.go
+++ b/build/build.go
@@ -49,6 +49,7 @@ func BundleScripts() error {
 	res := api.Build(api.BuildOptions{
 		EntryPoints: []string{
 			"injected/src/entrypoints/library.ts",
+			"injected/src/entrypoints/keyboard.ts",
 			"injected/src/entrypoints/menu.ts",
 			"injected/src/entrypoints/quick-access.ts",
 			"injected/src/entrypoints/app-properties.ts",

--- a/cdp/steam_client.go
+++ b/cdp/steam_client.go
@@ -60,6 +60,7 @@ type SteamTarget string
 
 const (
 	LibraryTarget       SteamTarget = "SP"
+	KeyboardTarget      SteamTarget = "SP_Keyboard"
 	MenuTarget          SteamTarget = "MainMenu"
 	QuickAccessTarget   SteamTarget = "QuickAccess"
 	AppPropertiesTarget SteamTarget = "AppProperties"
@@ -68,7 +69,13 @@ const (
 type targetFilterFunc func(target *target.Info) bool
 
 func IsLibraryTarget(target *target.Info) bool {
-	return target.Title == "SP" || strings.HasPrefix(target.URL, "https://steamloopback.host/index.html")
+	return (target.Title == "SP" || strings.HasPrefix(target.URL, "https://steamloopback.host/index.html")) &&
+		!strings.Contains(target.URL, "IN_STANDALONE_KEYBOARD")
+}
+
+func IsKeyboardTarget(target *target.Info) bool {
+	return (target.Title == "SP" || strings.HasPrefix(target.URL, "https://steamloopback.host/index.html")) &&
+		strings.Contains(target.URL, "IN_STANDALONE_KEYBOARD")
 }
 
 func IsMenuTarget(target *target.Info) bool {
@@ -91,6 +98,8 @@ func (sc *SteamClient) WaitForTarget(steamTarget SteamTarget) error {
 	switch steamTarget {
 	case LibraryTarget:
 		isTarget = IsLibraryTarget
+	case KeyboardTarget:
+		isTarget = IsKeyboardTarget
 	case MenuTarget:
 		isTarget = IsMenuTarget
 	case QuickAccessTarget:
@@ -158,6 +167,14 @@ func (sc *SteamClient) runScriptInTarget(isTarget targetFilterFunc, script strin
 
 func (sc *SteamClient) RunScriptInLibrary(script string) error {
 	return sc.runScriptInTarget(IsLibraryTarget, script)
+}
+
+func (sc *SteamClient) RunScriptInKeyboard(script string) error {
+	if sc.UiMode != UIModeDesktop {
+		return fmt.Errorf("Scripts can only be run in keyboard context in desktop mode")
+	}
+
+	return sc.runScriptInTarget(IsKeyboardTarget, script)
 }
 
 func (sc *SteamClient) RunScriptInMenu(script string) error {

--- a/injected/src/entrypoints/keyboard.ts
+++ b/injected/src/entrypoints/keyboard.ts
@@ -9,7 +9,7 @@ const main = async () => {
     return;
   }
 
-  waitForElement(MENU_DESKTOP_SELECTORS.keyboardContainer);
+  await waitForElement(MENU_DESKTOP_SELECTORS.keyboardContainer);
 
   const smm = new SMM('keyboard');
   if (window.smm) {

--- a/injected/src/entrypoints/keyboard.ts
+++ b/injected/src/entrypoints/keyboard.ts
@@ -1,0 +1,23 @@
+import { MENU_DESKTOP_SELECTORS } from '../menu-manager/selectors';
+import { SMM } from '../smm';
+import { info, waitForElement } from '../util';
+
+const main = async () => {
+  info('Successfully injected keyboard script');
+
+  if (window.smmUIMode !== 'desktop') {
+    return;
+  }
+
+  waitForElement(MENU_DESKTOP_SELECTORS.keyboardContainer);
+
+  const smm = new SMM('keyboard');
+  if (window.smm) {
+    delete window.smm;
+  }
+  window.smm = smm;
+
+  await smm.loadPlugins();
+};
+
+main();

--- a/injected/src/menu-manager/selectors.ts
+++ b/injected/src/menu-manager/selectors.ts
@@ -12,4 +12,5 @@ export const MENU_DESKTOP_SELECTORS = {
   collectionsButtonInner: '[class*=gamelisthome_CollectionButton_]',
   libraryContainer: '[class^=library_Container_]',
   homeButton: '[class*=gamelistbar_HomeBox_] [class*=gamelisthome_Bar_]',
+  keyboardContainer: '[class^=virtualkeyboard_Keyboard_]',
 };

--- a/injected/src/smm.ts
+++ b/injected/src/smm.ts
@@ -94,7 +94,7 @@ class EventLockScreenClosed extends CustomEvent<void> {
 /**
  * @public
  */
-export type Entry = 'library' | 'menu' | 'quickAccess' | 'appProperties';
+export type Entry = 'library' | 'menu' | 'quickAccess' | 'appProperties' | 'keyboard';
 
 /**
  * @public
@@ -308,8 +308,6 @@ export class SMM extends EventTarget {
     info('Loading plugins...');
 
     // Inject plugins
-    // TODO: this will inject plugins into all contexts, but we don't know if
-    // other contexts have loaded yet
     try {
       await new Promise<void>((resolve) => {
         // This will be called once the server has loaded plugins
@@ -346,7 +344,7 @@ export class SMM extends EventTarget {
       return;
     }
 
-    info(`Loading plugin ${name}...`);
+    info(`Loading plugin ${pluginId}...`);
     this.currentPlugin = pluginId;
     await window.smmPlugins[pluginId].load(this);
     this.currentPlugin = undefined;

--- a/injected/src/smm.ts
+++ b/injected/src/smm.ts
@@ -94,7 +94,12 @@ class EventLockScreenClosed extends CustomEvent<void> {
 /**
  * @public
  */
-export type Entry = 'library' | 'menu' | 'quickAccess' | 'appProperties' | 'keyboard';
+export type Entry =
+  | 'library'
+  | 'menu'
+  | 'quickAccess'
+  | 'appProperties'
+  | 'keyboard';
 
 /**
  * @public

--- a/patcher/js_library_root_sp.go
+++ b/patcher/js_library_root_sp.go
@@ -119,14 +119,22 @@ func patchCoolClass(fileLines []string, origPath, serverPort, authToken string) 
 
 		window.addEventListener('load', () => {
 			console.info('[Crankshaft] Page loading, making request to inject service');
+
+			// Check if we're a standalone keyboard, or the library
+			let injectMethod = 'InjectService.InjectLibrary';
+			if (window.location.href.includes('IN_STANDALONE_KEYBOARD')) {
+				injectMethod = 'InjectService.InjectKeyboard';
+			}
+			console.log('Injecting with ' + injectMethod);
+
 			fetch('http://localhost:%[1]s/rpc', {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
-    			'X-Cs-Auth': window.csAuthToken,
+    				'X-Cs-Auth': window.csAuthToken,
 				},
 				body: JSON.stringify({
-					method: 'InjectService.InjectLibrary',
+					method: injectMethod,
 					params: [],
 					id: Date.now(),
 				}),

--- a/plugins/plugin_config.go
+++ b/plugins/plugin_config.go
@@ -17,6 +17,7 @@ type authorInfo struct {
 
 type entrypoint struct {
 	Library       bool `json:"library"`
+	Keyboard      bool `json:"keyboard"`
 	Menu          bool `json:"menu"`
 	QuickAccess   bool `json:"quickAccess" toml:"quick-access"`
 	AppProperties bool `json:"appProperties" toml:"app-properties"`

--- a/rpc/inject/plugins.go
+++ b/rpc/inject/plugins.go
@@ -13,6 +13,7 @@ type entry string
 
 const (
 	LibraryEntry       entry = "library"
+	KeyboardEntry      entry = "keyboard"
 	MenuEntry          entry = "menu"
 	QuickAccessEntry   entry = "quickAccess"
 	AppPropertiesEntry entry = "appProperties"
@@ -24,6 +25,8 @@ func (e entry) target() cdp.SteamTarget {
 	switch e {
 	case LibraryEntry:
 		return cdp.LibraryTarget
+	case KeyboardEntry:
+		return cdp.KeyboardTarget
 	case MenuEntry:
 		return cdp.MenuTarget
 	case QuickAccessEntry:
@@ -68,6 +71,8 @@ func (service *InjectService) InjectPlugins(r *http.Request, req *InjectPluginsA
 	switch req.Entrypoint {
 	case LibraryEntry:
 		steamClient.RunScriptInLibrary("window.csPluginsLoaded()")
+	case KeyboardEntry:
+		steamClient.RunScriptInKeyboard("window.csPluginsLoaded()")
 	case MenuEntry:
 		steamClient.RunScriptInMenu("window.csPluginsLoaded()")
 	case QuickAccessEntry:
@@ -113,6 +118,13 @@ func injectPlugin(steamClient *cdp.SteamClient, plugin plugins.Plugin, entrypoin
 		log.Println("Injecting", plugin.Id, "into library")
 		if err := steamClient.RunScriptInLibrary(plugin.Script); err != nil {
 			return fmt.Errorf(`Error injecting plugin "%s" into library: %v`, plugin.Config.Name, err)
+		}
+	}
+
+	if entrypoint == cdp.KeyboardTarget && pluginEntrypoints.Keyboard {
+		log.Println("Injecting", plugin.Id, "into keyboard")
+		if err := steamClient.RunScriptInKeyboard(plugin.Script); err != nil {
+			return fmt.Errorf(`Error injecting plugin "%s" into keyboard: %v`, plugin.Config.Name, err)
 		}
 	}
 

--- a/rpc/inject/scripts-dev.go
+++ b/rpc/inject/scripts-dev.go
@@ -7,6 +7,7 @@ package inject
 
 var sharedScript string
 var libraryScript string
+var keyboardScript string
 var menuScript string
 var quickAccessScript string
 var appPropertiesScript string

--- a/rpc/inject/scripts-embedded.go
+++ b/rpc/inject/scripts-embedded.go
@@ -15,6 +15,9 @@ var sharedScript string
 //go:embed scripts/library.js
 var libraryScript string
 
+//go:embed scripts/keyboard.js
+var keyboardScript string
+
 //go:embed scripts/menu.js
 var menuScript string
 


### PR DESCRIPTION
This change allows loading plugins on the OSK in Desktop mode by adding the "keyboard" entrypoint to the Desktop list of plugin.toml.

There is quite a delay between the keyboard loading and the plugin executing, due to the full Crankshaft backend being injected, which takes a second. I wouldn't recommend using this in a plugin at the moment due to this delay, but the framework laid here should work once that delay is fixed.

There is also a small change around the Systray stuff to stop a crash when running Crankshaft via SSH directly on the steam deck (DISPLAY isn't set, so the systray icon can't be used when run this way)