### PR TITLE
#70 - Wait for the startup video to finish before injecting Crankshaft

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,17 +59,23 @@ bundle-scripts:
 
 .PHONY: build
 build: bundle-scripts
-	mkdir rpc/inject/scripts
+	mkdir -p rpc/inject/scripts
 	cp .build/* rpc/inject/scripts
 	go run cmd/bundle-scripts/main.go
 	go build -o crankshaft cmd/crankshaft/*.go
 
 .PHONY: flatpak
 flatpak: bundle-scripts
-	mkdir rpc/inject/scripts
+	mkdir -p rpc/inject/scripts
 	cp .build/* rpc/inject/scripts
 	go run cmd/bundle-scripts/main.go
 	go build -tags=flatpak -o crankshaft cmd/crankshaft/*.go
+
+.PHONY: patch-flatpak
+patch-flatpak: flatpak
+	systemctl --user stop crankshaft.service
+	cp crankshaft $(shell flatpak info -l space.crankshaft.Crankshaft)/files/bin/crankshaft
+	systemctl --user start crankshaft.service
 
 .PHONY: api-extractor
 api-extractor:

--- a/cdp/cdp.go
+++ b/cdp/cdp.go
@@ -30,31 +30,27 @@ func GetSteamCtx(debugPort string) (ctx context.Context, cancel func(), err erro
 }
 
 func WaitForConnection(debugPort string) {
-	steamCtx, cancel, _ := GetSteamCtx(debugPort)
-
 	log.Println("Waiting to connect to Steam client...")
 
-	connected := false
-	for !connected {
-		cancel()
-		steamCtx, cancel, _ = GetSteamCtx(debugPort)
-
+	for {
+		steamCtx, cancel, _ := GetSteamCtx(debugPort)
 		targets, err := chromedp.Targets(steamCtx)
-		if err != nil {
-			time.Sleep(1 * time.Second)
-			continue
-		}
 
-		foundSp := false
-		for _, target := range targets {
-			if IsLibraryTarget(target) {
-				foundSp = true
+		if err == nil {
+			foundSp := false
+			for _, target := range targets {
+				if IsLibraryTarget(target) {
+					foundSp = true
+					break
+				}
+			}
+
+			if foundSp {
+				break
 			}
 		}
-		if foundSp {
-			connected = true
-		}
 
+		cancel()
 		time.Sleep(1 * time.Second)
 	}
 

--- a/cdp/steam_client.go
+++ b/cdp/steam_client.go
@@ -134,7 +134,7 @@ func (sc *SteamClient) runScriptInTarget(isTarget targetFilterFunc, script strin
 	var ctx context.Context = nil
 	retries := 0
 
-	for ctx == nil && retries < 10 {
+	for ctx == nil && retries < getTargetRetryMax {
 		if retries != 0 {
 			time.Sleep(1 * time.Second)
 		}

--- a/cmd/crankshaft/crankshaft.go
+++ b/cmd/crankshaft/crankshaft.go
@@ -43,9 +43,11 @@ func run() error {
 		return fmt.Errorf("Error ensuring directories exist: %v", err)
 	}
 
-	if err := setupLogging(logsDir); err != nil {
+	logFile, err := setupLogging(logsDir)
+	if err != nil {
 		return fmt.Errorf("Error setting up logging: %v", err)
 	}
+	defer logFile.Close()
 
 	crksftConfig, found, err := config.NewCrksftConfig(dataDir)
 	if err != nil {
@@ -77,6 +79,7 @@ func run() error {
 	waitAndPatch := func() error {
 		cdp.WaitForConnection(debugPort)
 		cdp.WaitForLibraryEl(debugPort)
+		cdp.WaitForVideoFinish(debugPort)
 		cdp.ShowLoadingIndicator(debugPort, serverPort, authToken)
 		err = patcher.Patch(debugPort, serverPort, steamPath, cacheDir, noCache, authToken)
 		if err != nil {

--- a/cmd/crankshaft/logs.go
+++ b/cmd/crankshaft/logs.go
@@ -11,18 +11,17 @@ import (
 
 // setupLogging sets up the default `log` logger to log to both stdout and a
 // log file.
-func setupLogging(logsDir string) error {
+func setupLogging(logsDir string) (*os.File, error) {
 	// Create log file
 	logFileName := time.Now().Format("2006-01-02-15_04_05")
 	logFile, err := os.OpenFile(path.Join(logsDir, logFileName), os.O_CREATE|os.O_WRONLY, 0755)
 	if err != nil {
-		return fmt.Errorf(`Error creating log file "%s": %v`, logFileName, err)
+		return nil, fmt.Errorf(`Error creating log file "%s": %v`, logFileName, err)
 	}
-	defer logFile.Close()
 
 	// Setup logging to write to stdout and log file
 	logWriter := io.MultiWriter(os.Stdout, logFile)
 	log.SetOutput(logWriter)
 
-	return nil
+	return logFile, nil
 }


### PR DESCRIPTION
Wait for the startup video to finish before injecting Crankshaft

Additional fixes:
- Fix logging
- Start the backend injection process on the lock screen if one is enabled -- Note that plugins themselves are not injected until the console is unlocked for the first time
- Remove an unneeded 1s delay in WaitForConnection
- Add a "patch-flatpak" make target that will patch the installed Crankshaft flatpak