### PR TITLE
Update systemd service file

### DIFF
--- a/autostart/crankshaft.service
+++ b/autostart/crankshaft.service
@@ -1,14 +1,15 @@
 [Unit]
 Description=Crankshaft Plugin Manager
 
+StartLimitBurst=10
+StartLimitIntervalSec=10
+
 [Service]
 ExecStart=/usr/bin/flatpak run space.crankshaft.Crankshaft
 ExecStop=-/usr/bin/pkill -x crankshaft
 ExecStopPost=-/usr/bin/flatpak run space.crankshaft.Crankshaft -cleanup
 
 Restart=on-failure
-StartLimitBurst=10
-StartLimitIntervalSec=10
 
 [Install]
 WantedBy=default.target

--- a/autostart/crankshaft.service
+++ b/autostart/crankshaft.service
@@ -6,7 +6,7 @@ StartLimitIntervalSec=10
 
 [Service]
 ExecStart=/usr/bin/flatpak run space.crankshaft.Crankshaft
-ExecStop=-/usr/bin/pkill -x crankshaft
+ExecStop=-/usr/bin/flatpak kill space.crankshaft.Crankshaft
 ExecStopPost=-/usr/bin/flatpak run space.crankshaft.Crankshaft -cleanup
 
 Restart=on-failure


### PR DESCRIPTION
Hi :wave: 

This PR makes two changes to the systemd unit file used for autostarting the application.

The `StartLimit` options were moved to the `[Unit]` section, this should stop a warning being logged in the status output of systemctl. You can read more about it [in the manpage](https://man.archlinux.org/man/systemd.unit.5.en#%5BUNIT%5D_SECTION_OPTIONS) and check with `systemd-analyze verify crankshaft.service`. This may have compatibility issues with older ( < 3.4 ) versions of SteamOS though, but I don't remember the systemd version of previous releases to check it myself.

The `ExecStop` command was updated to use the flatpak kill command, which will 100% of the time kill the correct application and probably is a better option for flatpak'ed apps.